### PR TITLE
feat: Add netem chaos tests

### DIFF
--- a/chaos/network/netem-800ms.yml
+++ b/chaos/network/netem-800ms.yml
@@ -1,0 +1,20 @@
+apiVersion: chaos-mesh.org/v1alpha1
+kind: NetworkChaos
+metadata:
+  name: solo-chaos-network-netem-800ms-{{.UUID}}
+  namespace: chaos-mesh
+spec:
+  action: netem
+  mode: all
+  selector:
+    namespaces:
+      - ${NAMESPACE}
+    labelSelectors:
+      'solo.hedera.com/type': 'network-node'
+      'solo.hedera.com/latency': ''
+  delay:
+    latency: '800ms'
+    correlation: '80'
+    jitter: '20ms'
+  rate:
+    rate: '1gbps'

--- a/chaos/network/netem-800ms.yml
+++ b/chaos/network/netem-800ms.yml
@@ -1,7 +1,7 @@
 apiVersion: chaos-mesh.org/v1alpha1
 kind: NetworkChaos
 metadata:
-  name: solo-chaos-network-netem-800ms-{{.UUID}}
+  name: solo-chaos-network-netem-800ms-${UUID}
   namespace: chaos-mesh
 spec:
   action: netem
@@ -11,7 +11,7 @@ spec:
       - ${NAMESPACE}
     labelSelectors:
       'solo.hedera.com/type': 'network-node'
-      'solo.hedera.com/latency': ''
+      'solo.hedera.com/latency': '800ms'
   delay:
     latency: '800ms'
     correlation: '80'

--- a/chaos/network/netem-ap-melbourne.yml
+++ b/chaos/network/netem-ap-melbourne.yml
@@ -1,0 +1,20 @@
+apiVersion: chaos-mesh.org/v1alpha1
+kind: NetworkChaos
+metadata:
+  name: solo-chaos-network-netem-ap-melbourne-{{.UUID}}
+  namespace: chaos-mesh
+spec:
+  action: netem
+  mode: all
+  selector:
+    namespaces:
+      - ${NAMESPACE}
+    labelSelectors:
+      'solo.hedera.com/type': 'network-node'
+      'solo.hedera.com/region': 'ap'
+  delay:
+    latency: '200ms'
+    correlation: '80'
+    jitter: '20ms'
+  rate:
+    rate: '1gbps'

--- a/chaos/network/netem-ap-melbourne.yml
+++ b/chaos/network/netem-ap-melbourne.yml
@@ -1,7 +1,7 @@
 apiVersion: chaos-mesh.org/v1alpha1
 kind: NetworkChaos
 metadata:
-  name: solo-chaos-network-netem-ap-melbourne-{{.UUID}}
+  name: solo-chaos-network-netem-ap-melbourne-${UUID}
   namespace: chaos-mesh
 spec:
   action: netem

--- a/chaos/network/netem-eu-london.yml
+++ b/chaos/network/netem-eu-london.yml
@@ -1,7 +1,7 @@
 apiVersion: chaos-mesh.org/v1alpha1
 kind: NetworkChaos
 metadata:
-  name: solo-chaos-network-netem-eu-london-{{.UUID}}
+  name: solo-chaos-network-netem-eu-london-${UUID}
   namespace: chaos-mesh
 spec:
   action: netem

--- a/chaos/network/netem-eu-london.yml
+++ b/chaos/network/netem-eu-london.yml
@@ -1,0 +1,20 @@
+apiVersion: chaos-mesh.org/v1alpha1
+kind: NetworkChaos
+metadata:
+  name: solo-chaos-network-netem-eu-london-{{.UUID}}
+  namespace: chaos-mesh
+spec:
+  action: netem
+  mode: all
+  selector:
+    namespaces:
+      - ${NAMESPACE}
+    labelSelectors:
+      'solo.hedera.com/type': 'network-node'
+      'solo.hedera.com/region': 'eu'
+  delay:
+    latency: '100ms'
+    correlation: '80'
+    jitter: '20ms'
+  rate:
+    rate: '1gbps'

--- a/chaos/network/netem-us-ohio.yml
+++ b/chaos/network/netem-us-ohio.yml
@@ -1,0 +1,20 @@
+apiVersion: chaos-mesh.org/v1alpha1
+kind: NetworkChaos
+metadata:
+  name: solo-chaos-network-netem-us-ohio-{{.UUID}}
+  namespace: chaos-mesh
+spec:
+  action: netem
+  mode: all
+  selector:
+    namespaces:
+      - ${NAMESPACE}
+    labelSelectors:
+      'solo.hedera.com/type': 'network-node'
+      'solo.hedera.com/region': 'us'
+  delay:
+    latency: '50ms'
+    correlation: '80'
+    jitter: '20ms'
+  rate:
+    rate: '1gbps'

--- a/chaos/network/netem-us-ohio.yml
+++ b/chaos/network/netem-us-ohio.yml
@@ -1,7 +1,7 @@
 apiVersion: chaos-mesh.org/v1alpha1
 kind: NetworkChaos
 metadata:
-  name: solo-chaos-network-netem-us-ohio-{{.UUID}}
+  name: solo-chaos-network-netem-us-ohio-${UUID}
   namespace: chaos-mesh
 spec:
   action: netem

--- a/dev/config/solo-values.yml
+++ b/dev/config/solo-values.yml
@@ -1,0 +1,27 @@
+hedera:
+  nodes:
+    - name: node1
+      nodeId: 0
+      accountId: 0.0.3
+      labels:
+        solo.hedera.com/region: 'us'
+    - name: node2
+      nodeId: 1
+      accountId: 0.0.4
+      labels:
+        solo.hedera.com/region: 'us'
+    - name: node3
+      nodeId: 2
+      accountId: 0.0.5
+      labels:
+        solo.hedera.com/region: 'eu'
+    - name: node4
+      nodeId: 3
+      accountId: 0.0.6
+      labels:
+        solo.hedera.com/region: 'eu'
+    - name: node5
+      nodeId: 4
+      accountId: 0.0.7
+      labels:
+        solo.hedera.com/region: 'ap'

--- a/dev/k8s/cluster-diagnostics.yaml
+++ b/dev/k8s/cluster-diagnostics.yaml
@@ -56,23 +56,18 @@ data:
     ${SUDO} socat -lh -lu -v TCP4-LISTEN:8080,fork EXEC:cat & 
     exec sleep infinity
 ---
+# Headless service for direct pod access (ping, iperf3, etc.)
 apiVersion: v1
 kind: Service
 metadata:
   name: node1-svc
   namespace: cluster-diagnostics
-  annotations:
-    service.beta.kubernetes.io/aws-load-balancer-internal: "true"
-    service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
-    service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
-    networking.gke.io/load-balancer-type: "Internal"
 spec:
   selector:
     app: cluster-diagnostics
     solo.hedera.com/node-name: 'node1'
-  type: LoadBalancer
-  externalTrafficPolicy: Cluster
-  internalTrafficPolicy: Cluster
+  type: ClusterIP
+  clusterIP: None
   ports:
     - name: socat
       port: 8080
@@ -82,24 +77,20 @@ spec:
       port: 8081
       targetPort: 8081
       protocol: TCP
+
 ---
+# Headless service for direct pod access (ping, iperf3, etc.)
 apiVersion: v1
 kind: Service
 metadata:
   name: node2-svc
   namespace: cluster-diagnostics
-  annotations:
-    service.beta.kubernetes.io/aws-load-balancer-internal: "true"
-    service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
-    service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
-    networking.gke.io/load-balancer-type: "Internal"
 spec:
   selector:
     app: cluster-diagnostics
     solo.hedera.com/node-name: 'node2'
-  type: LoadBalancer
-  externalTrafficPolicy: Cluster
-  internalTrafficPolicy: Cluster
+  type: ClusterIP
+  clusterIP: None
   ports:
     - name: socat
       port: 8080
@@ -109,24 +100,20 @@ spec:
       port: 8081
       targetPort: 8081
       protocol: TCP
+
 ---
+# Headless service for direct pod access (ping, iperf3, etc.)
 apiVersion: v1
 kind: Service
 metadata:
   name: node3-svc
   namespace: cluster-diagnostics
-  annotations:
-    service.beta.kubernetes.io/aws-load-balancer-internal: "true"
-    service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
-    service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
-    networking.gke.io/load-balancer-type: "Internal"
 spec:
   selector:
     app: cluster-diagnostics
     solo.hedera.com/node-name: 'node3'
-  type: LoadBalancer
-  externalTrafficPolicy: Cluster
-  internalTrafficPolicy: Cluster
+  type: ClusterIP
+  clusterIP: None
   ports:
     - name: socat
       port: 8080
@@ -136,24 +123,20 @@ spec:
       port: 8081
       targetPort: 8081
       protocol: TCP
+
 ---
+# Headless service for direct pod access (ping, iperf3, etc.)
 apiVersion: v1
 kind: Service
 metadata:
   name: node4-svc
   namespace: cluster-diagnostics
-  annotations:
-    service.beta.kubernetes.io/aws-load-balancer-internal: "true"
-    service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
-    service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
-    networking.gke.io/load-balancer-type: "Internal"
 spec:
   selector:
     app: cluster-diagnostics
     solo.hedera.com/node-name: 'node4'
-  type: LoadBalancer
-  externalTrafficPolicy: Cluster
-  internalTrafficPolicy: Cluster
+  type: ClusterIP
+  clusterIP: None
   ports:
     - name: socat
       port: 8080
@@ -163,6 +146,7 @@ spec:
       port: 8081
       targetPort: 8081
       protocol: TCP
+
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/dev/k8s/cluster-diagnostics.yaml
+++ b/dev/k8s/cluster-diagnostics.yaml
@@ -59,7 +59,7 @@ data:
 apiVersion: v1
 kind: Service
 metadata:
-  name: cluster-diagnostics-svc
+  name: node1-svc
   namespace: cluster-diagnostics
   annotations:
     service.beta.kubernetes.io/aws-load-balancer-internal: "true"
@@ -69,6 +69,88 @@ metadata:
 spec:
   selector:
     app: cluster-diagnostics
+    solo.hedera.com/node-name: 'node1'
+  type: LoadBalancer
+  externalTrafficPolicy: Cluster
+  internalTrafficPolicy: Cluster
+  ports:
+    - name: socat
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+    - name: iperf3
+      port: 8081
+      targetPort: 8081
+      protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: node2-svc
+  namespace: cluster-diagnostics
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-internal: "true"
+    service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+    service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
+    networking.gke.io/load-balancer-type: "Internal"
+spec:
+  selector:
+    app: cluster-diagnostics
+    solo.hedera.com/node-name: 'node2'
+  type: LoadBalancer
+  externalTrafficPolicy: Cluster
+  internalTrafficPolicy: Cluster
+  ports:
+    - name: socat
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+    - name: iperf3
+      port: 8081
+      targetPort: 8081
+      protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: node3-svc
+  namespace: cluster-diagnostics
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-internal: "true"
+    service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+    service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
+    networking.gke.io/load-balancer-type: "Internal"
+spec:
+  selector:
+    app: cluster-diagnostics
+    solo.hedera.com/node-name: 'node3'
+  type: LoadBalancer
+  externalTrafficPolicy: Cluster
+  internalTrafficPolicy: Cluster
+  ports:
+    - name: socat
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+    - name: iperf3
+      port: 8081
+      targetPort: 8081
+      protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: node4-svc
+  namespace: cluster-diagnostics
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-internal: "true"
+    service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+    service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
+    networking.gke.io/load-balancer-type: "Internal"
+spec:
+  selector:
+    app: cluster-diagnostics
+    solo.hedera.com/node-name: 'node4'
   type: LoadBalancer
   externalTrafficPolicy: Cluster
   internalTrafficPolicy: Cluster
@@ -129,7 +211,9 @@ spec:
         metadata:
           labels:
             app: cluster-diagnostics
-            region: us
+            solo.hedera.com/node-name: 'node1'
+            solo.hedera.com/type: 'network-node'
+            solo.hedera.com/region: 'ap'
         spec:
           serviceAccountName: cluster-diagnostics-sa
           automountServiceAccountToken: true
@@ -156,18 +240,20 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: cluster-diagnosticss-node2
+  name: cluster-diagnostics-node2
   namespace: cluster-diagnostics
 spec:
     replicas: 1
     selector:
       matchLabels:
         app: cluster-diagnostics
-        region: eu
     template:
         metadata:
           labels:
             app: cluster-diagnostics
+            solo.hedera.com/node-name: 'node2'
+            solo.hedera.com/type: 'network-node'
+            solo.hedera.com/region: 'eu'
         spec:
           serviceAccountName: cluster-diagnostics-sa
           automountServiceAccountToken: true
@@ -194,7 +280,7 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: cluster-diagnosticss-node3
+  name: cluster-diagnostics-node3
   namespace: cluster-diagnostics
 spec:
     replicas: 1
@@ -205,7 +291,9 @@ spec:
         metadata:
           labels:
             app: cluster-diagnostics
-            region: apac
+            solo.hedera.com/node-name: 'node3'
+            solo.hedera.com/type: 'network-node'
+            solo.hedera.com/region: 'us'
         spec:
           serviceAccountName: cluster-diagnostics-sa
           automountServiceAccountToken: true
@@ -228,3 +316,43 @@ spec:
             - name: entrypoint
               configMap:
                 name: cluster-diagnostics-cm
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cluster-diagnostics-node4
+  namespace: cluster-diagnostics
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cluster-diagnostics
+  template:
+    metadata:
+      labels:
+        app: cluster-diagnostics
+        solo.hedera.com/node-name: 'node4'
+        solo.hedera.com/type: 'network-node'
+        solo.hedera.com/latency: '800ms'
+    spec:
+      serviceAccountName: cluster-diagnostics-sa
+      automountServiceAccountToken: true
+      containers:
+        - name: cluster-diagnostics
+          image: debian:bookworm-20250811-slim
+          command: ["/bin/bash", "/app/entrypoint.sh"]
+          volumeMounts:
+            - name: entrypoint
+              mountPath: /app/entrypoint.sh
+              subPath: entrypoint.sh
+          ports:
+            - containerPort: 8080
+              name: socat
+              protocol: TCP
+            - containerPort: 8081
+              name: iperf3
+              protocol: TCP
+      volumes:
+        - name: entrypoint
+          configMap:
+            name: cluster-diagnostics-cm

--- a/dev/k8s/cluster-diagnostics.yaml
+++ b/dev/k8s/cluster-diagnostics.yaml
@@ -1,0 +1,230 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cluster-diagnostics
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-diagnostics-cm
+  namespace: cluster-diagnostics
+data:
+  entrypoint.sh: |
+    #!/usr/bin/env bash
+    set -eo pipefail
+    
+    uid="$(id -u)"
+    
+    SUDO=""
+    if [[ "${uid}" -ne 0 ]]; then
+      if ! command -v sudo >/dev/null 2>&1; then
+        echo "FATAL: sudo is required to run this script as a non-root user"
+        exit 1
+      fi
+      
+      SUDO="$(command -v sudo)"
+    fi
+    
+    export DEBIAN_FRONTEND=noninteractive
+    
+    ${SUDO} apt update
+    ${SUDO} apt upgrade -y
+    ${SUDO} apt install -y curl ca-certificates jq netcat-traditional \
+      dnsutils iperf3 iputils-ping iproute2 tcpdump iputils-tracepath socat
+    
+    export ARCH="$(uname -m)"
+    case "${ARCH}" in
+      x86_64|amd64)
+        ARCH="amd64"
+        ;;
+      aarch64|arm64)
+        ARCH="arm64"
+        ;;
+      *)
+        echo "FATAL: Unsupported architecture: ${ARCH}"
+        exit 1
+        ;;
+    esac
+    
+    ${SUDO} curl -Lo /usr/local/bin/kubectl "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/${ARCH}/kubectl"
+    ${SUDO} chmod +x /usr/local/bin/kubectl
+    
+    [[ -d /app ]] || ${SUDO} mkdir -p /app
+    
+    ${SUDO} iperf3 -p 8081 -s --timestamps &
+    ${SUDO} socat -lh -lu -v TCP4-LISTEN:8080,fork EXEC:cat & 
+    exec sleep infinity
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cluster-diagnostics-svc
+  namespace: cluster-diagnostics
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-internal: "true"
+    service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+    service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
+    networking.gke.io/load-balancer-type: "Internal"
+spec:
+  selector:
+    app: cluster-diagnostics
+  type: LoadBalancer
+  externalTrafficPolicy: Cluster
+  internalTrafficPolicy: Cluster
+  ports:
+    - name: socat
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+    - name: iperf3
+      port: 8081
+      targetPort: 8081
+      protocol: TCP
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cluster-diagnostics-sa
+  namespace: cluster-diagnostics
+automountServiceAccountToken: true
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cluster-diagnostics-role
+rules:
+  - apiGroups: [""]
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cluster-diagnostics-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-diagnostics-role
+subjects:
+  - kind: ServiceAccount
+    name: cluster-diagnostics-sa
+    namespace: cluster-diagnostics
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cluster-diagnostics-node1
+  namespace: cluster-diagnostics
+spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app: cluster-diagnostics
+    template:
+        metadata:
+          labels:
+            app: cluster-diagnostics
+            region: us
+        spec:
+          serviceAccountName: cluster-diagnostics-sa
+          automountServiceAccountToken: true
+          containers:
+            - name: cluster-diagnostics
+              image: debian:bookworm-20250811-slim
+              command: ["/bin/bash", "/app/entrypoint.sh"]
+              volumeMounts:
+                - name: entrypoint
+                  mountPath: /app/entrypoint.sh
+                  subPath: entrypoint.sh
+              ports:
+                - containerPort: 8080
+                  name: socat
+                  protocol: TCP
+                - containerPort: 8081
+                  name: iperf3
+                  protocol: TCP
+          volumes:
+            - name: entrypoint
+              configMap:
+                name: cluster-diagnostics-cm
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cluster-diagnosticss-node2
+  namespace: cluster-diagnostics
+spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app: cluster-diagnostics
+        region: eu
+    template:
+        metadata:
+          labels:
+            app: cluster-diagnostics
+        spec:
+          serviceAccountName: cluster-diagnostics-sa
+          automountServiceAccountToken: true
+          containers:
+            - name: cluster-diagnostics
+              image: debian:bookworm-20250811-slim
+              command: ["/bin/bash", "/app/entrypoint.sh"]
+              volumeMounts:
+                - name: entrypoint
+                  mountPath: /app/entrypoint.sh
+                  subPath: entrypoint.sh
+              ports:
+                - containerPort: 8080
+                  name: socat
+                  protocol: TCP
+                - containerPort: 8081
+                  name: iperf3
+                  protocol: TCP
+          volumes:
+            - name: entrypoint
+              configMap:
+                name: cluster-diagnostics-cm
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cluster-diagnosticss-node3
+  namespace: cluster-diagnostics
+spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app: cluster-diagnostics
+    template:
+        metadata:
+          labels:
+            app: cluster-diagnostics
+            region: apac
+        spec:
+          serviceAccountName: cluster-diagnostics-sa
+          automountServiceAccountToken: true
+          containers:
+            - name: cluster-diagnostics
+              image: debian:bookworm-20250811-slim
+              command: ["/bin/bash", "/app/entrypoint.sh"]
+              volumeMounts:
+                - name: entrypoint
+                  mountPath: /app/entrypoint.sh
+                  subPath: entrypoint.sh
+              ports:
+                - containerPort: 8080
+                  name: socat
+                  protocol: TCP
+                - containerPort: 8081
+                  name: iperf3
+                  protocol: TCP
+          volumes:
+            - name: entrypoint
+              configMap:
+                name: cluster-diagnostics-cm

--- a/dev/taskfile/Taskfile.chaos.network.yml
+++ b/dev/taskfile/Taskfile.chaos.network.yml
@@ -25,3 +25,23 @@ tasks:
       LIMIT: "{{.LIMIT}}"
       BUFFER: "{{.BUFFER}}"
       UUID: "{{.UUID}}"
+
+  consensus-network-netem:
+    desc: Run Network Chaos experiments (network emulation)
+    vars:
+      NAMESPACE: "{{.SOLO_NAMESPACE}}"
+    cmds:
+      - echo "🔄 Running Network Bandwidth Chaos experiments..."
+      - echo "NAMESPACE=${NAMESPACE}, UUID=${UUID}"
+      - envsubst < ../../chaos/network/netem-800ms.yml | kubectl apply -f -
+      - envsubst < ../../chaos/network/netem-ap-melbourne.yml | kubectl apply -f -
+      - envsubst < ../../chaos/network/netem-eu-london.ymll | kubectl apply -f -
+      - envsubst < ../../chaos/network/netem-us-ohio.yml | kubectl apply -f -
+      - echo "✅ Netem Bandwidth Chaos experiments applied."
+      - task chaos:show-experiment-status NAME="solo-chaos-network-netem-800ms-{{.UUID}}" TYPE="NetworkChaos"
+      - task chaos:show-experiment-status NAME="solo-chaos-network-netem-ap-melbourne-{{.UUID}}" TYPE="NetworkChaos"
+      - task chaos:show-experiment-status NAME="solo-chaos-network-netem-eu-london-{{.UUID}}" TYPE="NetworkChaos"
+      - task chaos:show-experiment-status NAME="solo-chaos-network-netem-us-ohio-{{.UUID}}" TYPE="NetworkChaos"
+    env:
+      NAMESPACE: "{{.NAMESPACE}}"
+      UUID: "{{.UUID}}"

--- a/dev/taskfile/Taskfile.chaos.network.yml
+++ b/dev/taskfile/Taskfile.chaos.network.yml
@@ -29,7 +29,7 @@ tasks:
   consensus-network-netem:
     desc: Run Network Chaos experiments (network emulation)
     vars:
-      NAMESPACE: "{{.SOLO_NAMESPACE}}"
+      NAMESPACE: "{{.NAMESPACE | default .SOLO_NAMESPACE}}"
     cmds:
       - echo "🔄 Running Network Bandwidth Chaos experiments..."
       - echo "NAMESPACE=${NAMESPACE}, UUID=${UUID}"

--- a/dev/taskfile/Taskfile.chaos.network.yml
+++ b/dev/taskfile/Taskfile.chaos.network.yml
@@ -35,7 +35,7 @@ tasks:
       - echo "NAMESPACE=${NAMESPACE}, UUID=${UUID}"
       - envsubst < ../../chaos/network/netem-800ms.yml | kubectl apply -f -
       - envsubst < ../../chaos/network/netem-ap-melbourne.yml | kubectl apply -f -
-      - envsubst < ../../chaos/network/netem-eu-london.ymll | kubectl apply -f -
+      - envsubst < ../../chaos/network/netem-eu-london.yml | kubectl apply -f -
       - envsubst < ../../chaos/network/netem-us-ohio.yml | kubectl apply -f -
       - echo "✅ Netem Bandwidth Chaos experiments applied."
       - task chaos:show-experiment-status NAME="solo-chaos-network-netem-800ms-{{.UUID}}" TYPE="NetworkChaos"

--- a/dev/taskfile/Taskfile.root.yml
+++ b/dev/taskfile/Taskfile.root.yml
@@ -41,7 +41,7 @@ tasks:
       - solo deployment add-cluster --deployment "{{.SOLO_DEPLOYMENT}}" --cluster-ref kind-{{.SOLO_CLUSTER_NAME}} --num-consensus-nodes {{.NODES}}
       - solo node keys --gossip-keys --tls-keys --deployment "{{.SOLO_DEPLOYMENT}}"
       - solo cluster-ref setup -s "{{.SOLO_CLUSTER_SETUP_NAMESPACE}}"
-      - solo network deploy --deployment "{{.SOLO_DEPLOYMENT}}"
+      - solo network deploy --deployment "{{.SOLO_DEPLOYMENT}}" -f ../config/solo-values.yml
       - solo node setup --deployment "{{.SOLO_DEPLOYMENT}}"
       - solo node start --deployment "{{.SOLO_DEPLOYMENT}}"
       - |
@@ -265,6 +265,6 @@ tasks:
           echo '❌ NODE variable is required. Usage: task refresh-node -- NODE=node1'
           exit 1
         fi
-        " 
+        "
         solo node setup --deployment "{{.SOLO_DEPLOYMENT}}" -i {{.NODE}}
         solo node start --deployment "{{.SOLO_DEPLOYMENT}}" -i {{.NODE}}


### PR DESCRIPTION
This pull request introduces new configuration files and automation to support network chaos experiments and diagnostics for Hedera solo network nodes. The main changes include new Chaos Mesh definitions for network emulation, a diagnostics Kubernetes setup, and updates to deployment and task automation to use these new resources.

**Network Chaos Experimentation:**

* Added four new Chaos Mesh `NetworkChaos` YAML files (`netem-800ms.yml`, `netem-ap-melbourne.yml`, `netem-eu-london.yml`, `netem-us-ohio.yml`) to emulate latency, jitter, and bandwidth constraints for network nodes in different regions and with specific latency profiles. [[1]](diffhunk://#diff-13b84ceff53676ad051e583fa8fb18bbc904622036d1c4d2c68758b8fe258ae4R1-R20) [[2]](diffhunk://#diff-c3fb60fe3ca50373bed309dd3d6556193303b7123d630cf74be424bbc425e86eR1-R20) [[3]](diffhunk://#diff-6adef8f08cbc10dd8362770e37d53ff00463d08084e6d90b78d224f96dda6167R1-R20) [[4]](diffhunk://#diff-d265a5bfde8170ad0f008e078513604c357b634766366bcd0e1d198ff0c407b1R1-R20)
* Introduced a new `consensus-network-netem` task in `Taskfile.chaos.network.yml` to automate applying these network chaos experiments and checking their status.

**Diagnostics Infrastructure:**

* Added a comprehensive Kubernetes manifest (`cluster-diagnostics.yaml`) that sets up a diagnostics namespace, config map, service accounts, RBAC, services, and deployments for four diagnostic nodes, each tagged with region and type labels to match the network node setup. This enables direct pod access and network testing tools for each node.

**Configuration and Deployment Updates:**

* Added a new `solo-values.yml` configuration file specifying five Hedera nodes with region labels for use in deployments and chaos experiments.
* Updated the root deployment task to use the new `solo-values.yml` file, ensuring nodes are deployed with the correct regional configuration.

Closes #4
Closes #5 
Closes #6 