### PR TITLE
chore: fix destroy network command

### DIFF
--- a/dev/taskfile/Taskfile.root.yml
+++ b/dev/taskfile/Taskfile.root.yml
@@ -41,7 +41,7 @@ tasks:
       - solo deployment add-cluster --deployment "{{.SOLO_DEPLOYMENT}}" --cluster-ref kind-{{.SOLO_CLUSTER_NAME}} --num-consensus-nodes {{.NODES}}
       - solo node keys --gossip-keys --tls-keys --deployment "{{.SOLO_DEPLOYMENT}}"
       - solo cluster-ref setup -s "{{.SOLO_CLUSTER_SETUP_NAMESPACE}}"
-      - solo network deploy --deployment "{{.SOLO_DEPLOYMENT}}" -f ../config/solo-values.yml
+      - solo network deploy --deployment "{{.SOLO_DEPLOYMENT}}" -f ../config/solo-values.yml --solo-chart-version v0.56.0
       - solo node setup --deployment "{{.SOLO_DEPLOYMENT}}"
       - solo node start --deployment "{{.SOLO_DEPLOYMENT}}"
       - |
@@ -66,6 +66,8 @@ tasks:
     silent: true
     cmds:
       - echo "💣 Destroying existing Solo network (if any)..."
+      - helm uninstall solo-cluster-setup -n "{{.SOLO_CLUSTER_SETUP_NAMESPACE}}" --wait --ignore-not-found || true
+      - kubectl delete ns "{{.SOLO_CLUSTER_SETUP_NAMESPACE}}" --wait --ignore-not-found || true
       - kubectl delete ns "{{.SOLO_NAMESPACE}}" --wait --ignore-not-found || true
       - rm -rf ~/.solo || true
       - echo "✅ Solo network destroyed."
@@ -116,10 +118,6 @@ tasks:
         kubectl patch deployment -n kube-system metrics-server --type='json' \
           -p='[{"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--kubelet-insecure-tls"}]'
         echo "Metrics server is enabled."
-  
-  
-  
-  
   
   run-proxy:
     desc: Run a proxy to the Solo network (daemon mode, idempotent)


### PR DESCRIPTION
This pull request updates the Solo network deployment and destruction tasks to improve reproducibility and cleanup. The most important changes are:

Deployment version pinning:

* Updated the `solo network deploy` command to explicitly set the Solo chart version to `v0.54.5`, ensuring consistent deployments across environments.

Cleanup improvements:

* Enhanced the destroy task by adding commands to uninstall the `solo-cluster-setup` Helm release and delete its namespace, ensuring a more thorough cleanup of resources when tearing down the Solo network.