### PR TITLE
chore: remove permission from PR check

### DIFF
--- a/.github/workflows/flow-pull-request-formatting.yaml
+++ b/.github/workflows/flow-pull-request-formatting.yaml
@@ -13,7 +13,6 @@ defaults:
     shell: bash
 
 permissions:
-  contents: read
   statuses: write
 
 concurrency:


### PR DESCRIPTION
Removed read permission for contents in workflow.
